### PR TITLE
Pipeline transport test

### DIFF
--- a/src/ipc/session/detail/shm/classic/classic_fwd.hpp
+++ b/src/ipc/session/detail/shm/classic/classic_fwd.hpp
@@ -30,8 +30,6 @@ namespace ipc::session::shm::classic
 template<typename Session_impl_t>
 class Session_impl;
 
-class Server_session_impl_concrete;
-
 template<schema::MqType S_MQ_TYPE_OR_NONE, bool S_TRANSMIT_NATIVE_HANDLES, typename Mdt_payload>
 class Server_session_impl;
 

--- a/src/ipc/session/detail/shm/classic/server_session_impl.hpp
+++ b/src/ipc/session/detail/shm/classic/server_session_impl.hpp
@@ -28,6 +28,8 @@ namespace ipc::session::shm::classic
 
 // Types.
 
+/// XXX
+#if 0
 /// shm::classic::Server_session_impl helper that contains non-parameterized `public` items such as constants.
 class Server_session_impl_concrete
 {
@@ -47,6 +49,7 @@ public:
    */
   static constexpr size_t S_SHM_CLASSIC_POOL_SIZE_LIMIT_MI = 2048;
 };
+#endif
 
 /**
  * Core internally-used implementation of shm::classic::Server_session: it is to the latter what its `public`
@@ -278,8 +281,7 @@ void CLASS_CLSC_SRV_SESSION_IMPL::async_accept_log_in
                          / Shared_name::S_1ST_OR_ONLY;
 
     auto session_shm = make_unique<typename Base::Arena>(get_logger(), shm_pool_name, util::CREATE_ONLY,
-                                                         size_t(1024 * 1024) * Server_session_impl_concrete
-                                                                                 ::S_SHM_CLASSIC_POOL_SIZE_LIMIT_MI,
+                                                         size_t(1024 * 1024) * srv->pool_size_limit_mi(),
                                                          util::shared_resource_permissions
                                                            (srv_app.m_permissions_level_for_client_apps),
                                                          &err_code);

--- a/src/ipc/session/detail/shm/classic/server_session_impl.hpp
+++ b/src/ipc/session/detail/shm/classic/server_session_impl.hpp
@@ -28,29 +28,6 @@ namespace ipc::session::shm::classic
 
 // Types.
 
-/// XXX
-#if 0
-/// shm::classic::Server_session_impl helper that contains non-parameterized `public` items such as constants.
-class Server_session_impl_concrete
-{
-public:
-  // Constants.
-
-  /**
-   * Max size, in mebibytes, of each per-app and per-session pool.
-   *
-   * Note: this isn't how much RAM is taken away from all other uses;
-   * only a little bit is; this is only how much vaddr space (which is nearly unlimited) is reserved.
-   * Actual RAM is reserved on a ~page basis, once a given page has something written to it (such as by being
-   * allocated via `Pool_arena::allocate*()`, directly or otherwise).
-   *
-   * @todo Maybe make #S_SHM_CLASSIC_POOL_SIZE_LIMIT_MI configurable.  Investigate if it has effect on perf; and just
-   * generally investigate how this works in detail, at least in Linux, so we don't get into trouble.
-   */
-  static constexpr size_t S_SHM_CLASSIC_POOL_SIZE_LIMIT_MI = 2048;
-};
-#endif
-
 /**
  * Core internally-used implementation of shm::classic::Server_session: it is to the latter what its `public`
  * super-class Server_session_impl is to #Server_session.


### PR DESCRIPTION
ipc::shm::classic: On smaller machines (ex GitHub runners) can hit kernel limit on active pools total vaddr size (ex transport_test exercise mode) - Making the SHM-classic pool size (mostly an internal thing but it can hit kernel limit) optionally controllable via mutator on shm::classic::Session_server.  Also added accessor.