### PR TITLE
SHM-classic `borrow_object()` hardening: bad-input rejection and odd-alignment acceptance; pointer arithmetic hygiene. / `Pool_arena::is_handle_in_arena()` UB removal when `Pool_arena` didn't open SHM-pool. / `Logger* = nullptr` crash fix (test=>backport).

### DIFF
--- a/src/ipc/session/detail/shm/classic/session_impl.hpp
+++ b/src/ipc/session/detail/shm/classic/session_impl.hpp
@@ -328,6 +328,20 @@ typename CLASS_CLSC_SESSION_IMPL::Arena::template Handle<T>
                  "[" << buffers_dump_string(serialization.const_buffer(), "  ") << "].");
 
   Blob real_serialization(serialization); // Copy (it's small).
+
+  if (serialization.size() < sizeof(scope_id_t))
+  {
+    /* For safety let's do real runtime check rather than a mere (often skipped in release builds) assert().
+     * This is akin to how Pool_arena::borrow_object() (called below) would act if it's able to detect
+     * a bogus real_serialization. */
+    FLOW_LOG_WARNING("Session [" << *this << "]: SHM-classic-borrow serialization "
+                     "has incorrect size [" << serialization.size() << "] in that it cannot hold "
+                     "the Session-generated scope ID (size [" << sizeof(scope_id_t) << "]).  Borrow op fails.  "
+                     "Was there a bug in transmitting the blob returned by opposing lend_object()?");
+    return nullptr;
+  }
+  // else
+
   const auto real_serialization_sz = real_serialization.size() - sizeof(scope_id_t);
   real_serialization.start_past_prefix_inc(real_serialization_sz);
   // Copy it out of there (that should realign it at the target stack location).

--- a/src/ipc/session/detail/shm/classic/session_impl.hpp
+++ b/src/ipc/session/detail/shm/classic/session_impl.hpp
@@ -370,7 +370,7 @@ typename CLASS_CLSC_SESSION_IMPL::Arena::template Handle<T>
   // else
 
   FLOW_LOG_WARNING("Session [" << *this << "]: SHM-classic-borrow serialization "
-                   "has correct size, but invalid scope ID [" << scope_id << "].  Borrow op fails.  "
+                   "has correct size but invalid scope ID [" << scope_id << "].  Borrow op fails.  "
                    "Was there a bug in transmitting the blob returned by opposing lend_object()?");
   return nullptr;
 } // Session_impl::borrow_object()

--- a/src/ipc/session/detail/shm/classic/session_impl.hpp
+++ b/src/ipc/session/detail/shm/classic/session_impl.hpp
@@ -369,7 +369,9 @@ typename CLASS_CLSC_SESSION_IMPL::Arena::template Handle<T>
   }
   // else
 
-  assert(false && "borrow_object() called on invalid value?  Or bug -- forgot to update this method?  IPC fail?");
+  FLOW_LOG_WARNING("Session [" << *this << "]: SHM-classic-borrow serialization "
+                   "has correct size, but invalid scope ID [" << scope_id << "].  Borrow op fails.  "
+                   "Was there a bug in transmitting the blob returned by opposing lend_object()?");
   return nullptr;
 } // Session_impl::borrow_object()
 

--- a/src/ipc/session/detail/shm/classic/session_impl.hpp
+++ b/src/ipc/session/detail/shm/classic/session_impl.hpp
@@ -23,6 +23,7 @@
 #include "ipc/session/shm/classic/classic.hpp"
 #include "ipc/transport/struc/shm/classic/classic_fwd.hpp"
 #include "ipc/transport/struc/shm/classic/classic.hpp"
+#include <cstring>
 
 namespace ipc::session::shm::classic
 {
@@ -320,32 +321,39 @@ typename CLASS_CLSC_SESSION_IMPL::Arena::template Handle<T>
 {
   using util::Blob_const;
   using flow::util::buffers_dump_string;
+  using std::memcpy;
   using Value = T;
+  constexpr auto SCOPE_ID_SZ = sizeof(scope_id_t);
 
-  // This should be possible to understand if one has grokked borrow_object().
+  // This should be possible to understand if one has grokked lend_object().
 
   FLOW_LOG_TRACE("Session [" << *this << "]: SHM-classic-borrow serialization: "
                  "[" << buffers_dump_string(serialization.const_buffer(), "  ") << "].");
 
-  Blob real_serialization(serialization); // Copy (it's small).
-
-  if (serialization.size() < sizeof(scope_id_t))
+  if (serialization.size() < SCOPE_ID_SZ)
   {
     /* For safety let's do real runtime check rather than a mere (often skipped in release builds) assert().
      * This is akin to how Pool_arena::borrow_object() (called below) would act if it's able to detect
      * a bogus real_serialization. */
     FLOW_LOG_WARNING("Session [" << *this << "]: SHM-classic-borrow serialization "
                      "has incorrect size [" << serialization.size() << "] in that it cannot hold "
-                     "the Session-generated scope ID (size [" << sizeof(scope_id_t) << "]).  Borrow op fails.  "
+                     "the Session-generated scope ID (size [" << SCOPE_ID_SZ << "]).  Borrow op fails.  "
                      "Was there a bug in transmitting the blob returned by opposing lend_object()?");
     return nullptr;
   }
   // else
 
-  const auto real_serialization_sz = real_serialization.size() - sizeof(scope_id_t);
+  Blob real_serialization(serialization); // Copy (it's small).
+
+  const auto real_serialization_sz = real_serialization.size() - SCOPE_ID_SZ;
   real_serialization.start_past_prefix_inc(real_serialization_sz);
-  // Copy it out of there (that should realign it at the target stack location).
-  const auto scope_id = *(reinterpret_cast<const scope_id_t*>(real_serialization.const_data()));
+
+  /* real_serialization.data() is aligned fine if only due to being a (deep) copy.  However we don't know
+   * know for sure that real_serialization_sz implies alignment of scope_id immediately following.  Hence
+   * memcpy() -- do not assign, if only for that reason. */
+  scope_id_t scope_id;
+  memcpy(&scope_id, real_serialization.const_data(), SCOPE_ID_SZ);
+
   real_serialization.start_past_prefix_inc(-real_serialization_sz);
   real_serialization.resize(real_serialization_sz);
   // real_serialization is now the original Arena::lend_object() result.

--- a/src/ipc/shm/classic/pool_arena.cpp
+++ b/src/ipc/shm/classic/pool_arena.cpp
@@ -162,6 +162,13 @@ bool Pool_arena::deallocate(void* buf_not_null) noexcept
   return true;
 } // Pool_arena::deallocate()
 
+bool Pool_arena::is_addr_in_arena(const void* p) const
+{
+  // Pre-requisite to this internal helper is: m_pool is non-null.
+  const auto pool_base = static_cast<const uint8_t*>(m_pool->get_address());
+  return (p >= pool_base) && (p < (pool_base + m_pool->get_size()));
+}
+
 void Pool_arena::remove_persistent(flow::log::Logger* logger_ptr, // Static.
                                    const Shared_name& pool_name, Error_code* err_code)
 {

--- a/src/ipc/shm/classic/pool_arena.cpp
+++ b/src/ipc/shm/classic/pool_arena.cpp
@@ -39,9 +39,9 @@ Pool_arena::Pool_arena(Mode_tag mode_tag, flow::log::Logger* logger_ptr,
   constexpr char const * MODE_STR = std::is_same_v<Mode_tag, util::Create_only>
                                       ? "create-only" : "open-or-create";
 
-  if (get_logger()->should_log(flow::log::Sev::S_INFO, get_log_component()))
+  if (logger_ptr && logger_ptr->should_log(flow::log::Sev::S_INFO, get_log_component()))
   {
-    ios_all_saver saver{*(get_logger()->this_thread_ostream())}; // Revert std::oct/etc. soon.
+    ios_all_saver saver{*(logger_ptr->this_thread_ostream())}; // Revert std::oct/etc. soon.
     FLOW_LOG_INFO_WITHOUT_CHECKING
       ("SHM-classic pool [" << *this << "]: Constructing heap handle to heap/pool at name [" << m_pool_name << "] in "
        "[" << MODE_STR << "] mode; pool size [" << flow::util::ceil_div(pool_sz, size_t(1024 * 1024)) << "Mi]; "
@@ -110,7 +110,8 @@ void* Pool_arena::allocate(size_t n)
   }
   // else
 
-  if (get_logger()->should_log(flow::log::Sev::S_DATA, get_log_component()))
+  const auto logger_ptr = get_logger();
+  if (logger_ptr && logger_ptr->should_log(flow::log::Sev::S_DATA, get_log_component()))
   {
     const auto total = m_pool->get_size();
     const auto prev_free = m_pool->get_free_memory();
@@ -140,7 +141,8 @@ bool Pool_arena::deallocate(void* buf_not_null) noexcept
   }
   // else
 
-  if (get_logger()->should_log(flow::log::Sev::S_DATA, get_log_component()))
+  const auto logger_ptr = get_logger();
+  if (logger_ptr && logger_ptr->should_log(flow::log::Sev::S_DATA, get_log_component()))
   {
     const auto total = m_pool->get_size();
     const auto prev_free = m_pool->get_free_memory();

--- a/src/ipc/shm/classic/pool_arena.cpp
+++ b/src/ipc/shm/classic/pool_arena.cpp
@@ -165,8 +165,13 @@ bool Pool_arena::deallocate(void* buf_not_null) noexcept
 bool Pool_arena::is_addr_in_arena(const void* p) const
 {
   // Pre-requisite to this internal helper is: m_pool is non-null.
-  const auto pool_base = static_cast<const uint8_t*>(m_pool->get_address());
-  return (p >= pool_base) && (p < (pool_base + m_pool->get_size()));
+
+  /* Let's use pure integer arithmetic to avoid a genius optimizer detecting formal undefined-behavior
+   * (pointers outside data structures) and generating surprising results. */
+  const auto addr = reinterpret_cast<uintptr_t>(p);
+  const auto pool_base = reinterpret_cast<uintptr_t>(m_pool->get_address());
+  // Sidestep any (albeit very unlikely) wrap.
+  return (addr >= pool_base) && ((addr - pool_base) < m_pool->get_size());
 }
 
 void Pool_arena::remove_persistent(flow::log::Logger* logger_ptr, // Static.

--- a/src/ipc/shm/classic/pool_arena.hpp
+++ b/src/ipc/shm/classic/pool_arena.hpp
@@ -778,7 +778,7 @@ Pool_arena::Handle<T> Pool_arena::borrow_object(const Blob& serialization)
                      "Was there a bug in transmitting the blob returned by opposing lend_object()?");
     return Handle<Value>{};
   }
-  // else:
+  // else
 
   FLOW_LOG_TRACE("SHM-classic pool [" << *this << "]: Deserialized SHM outer handle "
                  "[" << static_cast<const void*>(handle_state) << "] "

--- a/src/ipc/shm/classic/pool_arena.hpp
+++ b/src/ipc/shm/classic/pool_arena.hpp
@@ -449,7 +449,8 @@ public:
 
   /**
    * Completes the cross-process operation begun by lend_object() that returned `serialization`; to be invoked in the
-   * intended new owner process.  Returns null if no pool attached to `*this`.
+   * intended new owner process.  Returns null if no pool attached to `*this`, or if we detect `serialization`
+   * to be invalid (best-effort check).
    *
    * Consider the only 2 ways a user may obtain a new #Handle to a `T` from `*this`:
    *   - construct(): This is allocation by the original/first owner of the `T`.
@@ -468,7 +469,8 @@ public:
    *         See lend_object().
    * @param serialization
    *        Value, not `.empty()`, returned by lend_object() and transmitted bit-for-bit to this process.
-   * @return Non-null on success; `null` if ctor failed to attach a pool.
+   * @return Non-null on success; `null` if ctor failed to attach a pool, or if `serialization` is invalid
+   *         (best-effort check).
    */
   template<typename T>
   Handle<T> borrow_object(const Blob& serialization);
@@ -481,8 +483,8 @@ public:
    *
    * @param handle
    *        An object, or copy/move of an object, returned by `construct<T>()` or `borrow_object<T>()`
-   *        of *a* Pool_arena (not necessarily `*this`), while `*this` was already constructed.
-   * @return See above.
+   *        of *a* Pool_arena (not necessarily `*this`).
+   * @return See above.  (Corner case: If ctor failed to attach a pool, we return `false`.)
    */
   template<typename T>
   bool is_handle_in_arena(const Handle<T>& handle) const;
@@ -608,6 +610,32 @@ private:
   template<typename T>
   void handle_deleter_impl(Handle_in_shm<T>* handle_state);
 
+  /**
+   * Returns `true` if and only if the byte at `p` is within the bounds of the pool accessed by `*this`.
+   *
+   * Assumes #m_pool is non-null; else undefined behavior.
+   *
+   * @param p
+   *        An address.
+   * @return See above.
+   */
+  bool is_addr_in_arena(const void* p) const;
+
+  /**
+   * Returns `true` if and only if all `sizeof(T)` bytes at address `obj` are within the bounds of the pool
+   * accessed by `*this`.
+   *
+   * Assumes #m_pool is non-null; else undefined behavior.
+   *
+   * @tparam T
+   *         Object type; `sizeof(T)` is significant in the calculation, so this is not mere syntactic sugar.
+   * @param obj
+   *        An address.
+   * @return See above.
+   */
+  template<typename T>
+  bool is_obj_in_arena(const T* obj) const;
+
   // Data.
 
   /// Attached SHM pool.  If ctor fails in non-throwing fashion then this remains null.  Immutable after ctor.
@@ -621,9 +649,26 @@ private:
 template<typename T>
 bool Pool_arena::is_handle_in_arena(const Handle<T>& handle) const
 {
-  const auto p = reinterpret_cast<const uint8_t*>(handle.get());
-  const auto pool_base = static_cast<const uint8_t*>(m_pool->get_address());
-  return (p >= pool_base) && (p < (pool_base + m_pool->get_size()));
+  /* Subtlety: This (public) method is not intended as a legitness check of `handle` but rather to indicate whether
+   * the assumed-legit `handle` coming from *a* Pool_arena came from the pool (if any) to which *this refers. */
+  return m_pool // Else couldn't open any pool in ctor.
+         && is_addr_in_arena(static_cast<const void*>(handle.get()));
+}
+
+template<typename T>
+bool Pool_arena::is_obj_in_arena(const T* obj) const
+{
+  // Pre-requisite to this internal helper is: m_pool is non-null.
+
+  if (!is_addr_in_arena(static_cast<const void*>(obj)))
+  {
+    return false;
+  }
+  // else: First byte of obj is in range; hence ensure its last byte isn't past range's last byte.
+
+  return (reinterpret_cast<const uint8_t*>(obj) + sizeof(T))
+         <= (static_cast<const uint8_t*>(m_pool->get_address())
+             + m_pool->get_size());
 }
 
 template<typename T, typename... Ctor_args>
@@ -648,13 +693,11 @@ Pool_arena::Handle<T> Pool_arena::construct(Ctor_args&&... ctor_args)
     construct_at(&handle_state->m_obj, std::forward<Ctor_args>(ctor_args)...);
   }
 
-  shared_ptr<Shm_handle> real_shm_handle{handle_state, [this](Shm_handle* handle_state)
-  {
-    handle_deleter_impl<Value>(handle_state);
-  }}; // Custom deleter.
-
-  // Return alias shared_ptr whose .get() gives &m_obj but in reality aliases to real_shm_handle.
-  return Handle<Value>{std::move(real_shm_handle), &handle_state->m_obj};
+  // Return alias shared_ptr whose .get() gives &m_obj but in reality aliases to the shared_ptr<Shm_handle>.
+  return Handle<Value>{shared_ptr<Shm_handle>{handle_state,
+                                              [this](Shm_handle* handle_state)
+                                                { handle_deleter_impl<Value>(handle_state); }}, // Custom deleter.
+                       &handle_state->m_obj};
 } // Pool_arena::construct()
 
 template<typename T>
@@ -704,8 +747,17 @@ Pool_arena::Handle<T> Pool_arena::borrow_object(const Blob& serialization)
   // else
 
   ptrdiff_t offset_from_pool_base;
-  assert((serialization.size() == sizeof(offset_from_pool_base))
-         && "lend_object() and borrow_object() incompatible?  Bug?");
+  if (serialization.size() != sizeof(offset_from_pool_base))
+  {
+    // For safety let's do real runtime check rather than a mere (often skipped in release builds) assert().
+    FLOW_LOG_WARNING("SHM-classic pool [" << *this << "]: In attempt to deserialize SHM outer handle "
+                     "(type [" << typeid(Value).name() << "]) "
+                     "after IPC-receipt detected incorrect size [" << serialization.size() << "] of the serialized "
+                     "SHM-handle blob (expected: [" << sizeof(offset_from_pool_base) << "]).  Borrow op fails.  "
+                     "Was there a bug in transmitting the blob returned by opposing lend_object()?");
+    return Handle<Value>{};
+  }
+  // else
 
   offset_from_pool_base = *(reinterpret_cast<decltype(offset_from_pool_base) const *>
                               (serialization.const_data()));
@@ -713,21 +765,35 @@ Pool_arena::Handle<T> Pool_arena::borrow_object(const Blob& serialization)
     = reinterpret_cast<Shm_handle*>
         (static_cast<uint8_t*>(m_pool->get_address()) + offset_from_pool_base);
 
-  // Now simply do just as in construct():
-
-  shared_ptr<Shm_handle> real_shm_handle{handle_state, [this](Shm_handle* handle_state)
+  /* Reminder: Shm_handle=Handle_in_shm<Value> -- our *handle_state in particular -- includes both the `Value` and
+   * the metadata (m_atomic_owner_ct as of this writing).  Hence this is a good safety check: */
+  if (!is_obj_in_arena(handle_state))
   {
-    handle_deleter_impl<Value>(handle_state);
-  }};
+    // Again: For safety let's log and abort rather than a mere (often skipped in release builds) assert().
+    FLOW_LOG_WARNING("SHM-classic pool [" << *this << "]: In attempt to deserialize SHM outer handle "
+                     "[" << static_cast<const void*>(handle_state) << "] "
+                     "(value+metadata size [" << sizeof(Shm_handle) << "], type [" << typeid(Value).name() << "]) "
+                     "after IPC-receipt detected that the value+metadata buffer is not wholly contained in "
+                     "our pool.  Borrow op fails.  "
+                     "Was there a bug in transmitting the blob returned by opposing lend_object()?");
+    return Handle<Value>{};
+  }
+  // else:
 
-  FLOW_LOG_TRACE("SHM-classic pool [" << *this << "]: Deserialized SHM outer handle [" << real_shm_handle << "] "
-                 "(type [" << typeid(Value).name() << "]) "
-                 "after IPC-receipt: Owner-count is at [" << handle_state->m_atomic_owner_ct << "] "
+  FLOW_LOG_TRACE("SHM-classic pool [" << *this << "]: Deserialized SHM outer handle "
+                 "[" << static_cast<const void*>(handle_state) << "] "
+                 "(type [" << typeid(Value).name() << "]) after IPC-receipt: "
+                 "Owner-count is at [" << handle_state->m_atomic_owner_ct << "] "
                  "(may change concurrently; but includes us at least hence must be 1+).  "
                  "Handle points to SHM-offset [" << offset_from_pool_base << "] (deserialized).  Serialized "
                  "contents are [" << buffers_dump_string(serialization.const_buffer(), "  ") << "].");
 
-  return Handle<Value>{std::move(real_shm_handle), &handle_state->m_obj};
+  // Now simply do just as in construct():
+
+  return Handle<Value>{shared_ptr<Shm_handle>{handle_state,
+                                              [this](Shm_handle* handle_state)
+                                                { handle_deleter_impl<Value>(handle_state); }},
+                       &handle_state->m_obj};
 } // Pool_arena::borrow_object()
 
 template<typename T>

--- a/src/ipc/shm/classic/pool_arena.hpp
+++ b/src/ipc/shm/classic/pool_arena.hpp
@@ -25,6 +25,7 @@
 #include <flow/util/basic_blob.hpp>
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/indexes/null_index.hpp>
+#include <cstring>
 #include <optional>
 
 namespace ipc::shm::classic
@@ -666,9 +667,11 @@ bool Pool_arena::is_obj_in_arena(const T* obj) const
   }
   // else: First byte of obj is in range; hence ensure its last byte isn't past range's last byte.
 
-  return (reinterpret_cast<const uint8_t*>(obj) + sizeof(T))
-         <= (static_cast<const uint8_t*>(m_pool->get_address())
-             + m_pool->get_size());
+  /* The arithmetic and casts probably look odd, but it's the same reasoning as in is_addr_in_arena();
+   * use integer arithmetic only and avoid wraps via + while using known-non-negative-result subtractions. */
+  return sizeof(T)
+         <= (m_pool->get_size() - (reinterpret_cast<uintptr_t>(obj)
+                                   - reinterpret_cast<uintptr_t>(m_pool->get_address())));
 }
 
 template<typename T, typename... Ctor_args>
@@ -717,8 +720,8 @@ Pool_arena::Blob Pool_arena::lend_object(const Handle<T>& handle)
   const auto handle_state = reinterpret_cast<Shm_handle*>(handle.get());
   const auto new_owner_ct = ++handle_state->m_atomic_owner_ct;
 
-  const ptrdiff_t offset_from_pool_base = reinterpret_cast<const uint8_t*>(handle_state)
-                                          - static_cast<const uint8_t*>(m_pool->get_address());
+  const ptrdiff_t offset_from_pool_base = reinterpret_cast<uintptr_t>(handle_state)
+                                          - reinterpret_cast<uintptr_t>(m_pool->get_address());
 
   Blob serialization{sizeof(offset_from_pool_base)};
   *(reinterpret_cast<ptrdiff_t*>(serialization.data())) = offset_from_pool_base;
@@ -739,6 +742,7 @@ Pool_arena::Handle<T> Pool_arena::borrow_object(const Blob& serialization)
   using Shm_handle = Handle_in_shm<Value>;
   using flow::util::buffers_dump_string;
   using boost::shared_ptr;
+  using std::memcpy;
 
   if (!m_pool)
   {
@@ -759,11 +763,14 @@ Pool_arena::Handle<T> Pool_arena::borrow_object(const Blob& serialization)
   }
   // else
 
-  offset_from_pool_base = *(reinterpret_cast<decltype(offset_from_pool_base) const *>
-                              (serialization.const_data()));
+  /* memcpy() it out of there: the source address may not be aligned.  (In many APIs such things are assumed as a
+   * matter of course, but as `serialization` may be IPCed-over to us via any technique, we're being
+   * extra defensive.) */
+  memcpy(&offset_from_pool_base, serialization.const_data(), sizeof(offset_from_pool_base));
+
   const auto handle_state
     = reinterpret_cast<Shm_handle*>
-        (static_cast<uint8_t*>(m_pool->get_address()) + offset_from_pool_base);
+        (reinterpret_cast<uintptr_t>(m_pool->get_address()) + offset_from_pool_base);
 
   /* Reminder: Shm_handle=Handle_in_shm<Value> -- our *handle_state in particular -- includes both the `Value` and
    * the metadata (m_atomic_owner_ct as of this writing).  Hence this is a good safety check: */


### PR DESCRIPTION
## Summary

* SHM-classic:
  * If using SHM-classic via an `ipc::shm::classic::Pool_arena` directly:
    * For `Pool_arena::borrow_object()`, harden its behavior against corrupt/erroneous input blob (which encodes the handle-to-SHM being transmitted from another process), including best-effort validation of the resulting pointee. Return null and log WARNING on detected corruption.
      * Also defensively handle unusually-aligned inputs and atypical virtual addresses, avoiding processor exceptions or exotic code generation.
  * If using SHM-classic via `ipc::session` as recommended:
    * For `ipc::session::shm::classic::Session::borrow_object()`, harden its behavior similarly to the above `Pool_arena::borrow_object()` improvements. This includes, but is not limited to, the benefits gained from those changes themselves, as `Session::borrow_object()` typically calls `Pool_arena::borrow_object()` (plus additional processing).
* Bug class (across various Flow-IPC modules) fix: The formally-allowed (and perfectly practical) `Logger* logger_ptr = nullptr` API arg value would result in a crash. 
  * This was ready in a coming-soon release, but new unit-testing for the above `borrow_object()` hardening, preceding that release, tickles it. Hence backporting the straightforward fix, though it is unrelated to the substance of the aforementioned hardening effort.
* Comment and/or doc changes.

## API notes
* In existing API `ipc::shm::classic::Pool_arena::is_handle_in_arena()`: now return `false` (instead of undefined behavior) if the constructor earlier failed to open-or-create the SHM-pool by name. 
  * This matches the behavior of other `Pool_arena::` APIs including `construct()`, `lend_object()`, `borrow_object()`.

## Impl notes
* List of `classic::Pool_arena::borrow_object()` blob inputs detected as invalid (return null): Wrong size (must equal pool-offset type size); pointee outside SHM-pool vaddr range; pointee + `sizeof(T)` + internal metadata = beyond end of said range.
* List of `session::classic::Session::borrow_object()` blob inputs detected as invalid (return null), in addition to the above: Wrong size (postfix must fit internal scope-ID: `enum`-like indicator); invalid internal scope-ID (neither session-scope or app-scope).
  * Previously the latter would trip `assert()` if assertions enabled. If assertions disabled behavior was already correct (on invalid scope ID).
* Pointer arithmetic hygiene: `uintptr_t` over `uint8_t*`; avoid `uintptr_t` wrapping in ptr+plus+offset calculations (use difference-calculations).
* Slight tightening (no functional difference) of `return`-stage code in `Pool_arena::construct<T>()` and `Pool_arena::borrow_object<T>()`.

## To code reviewer
* The core `borrow_object()` hardening changes are in this PR. They're straightforward, but there are a few combined.
* Tests are in different PR (different repo).
